### PR TITLE
Fixes #14.

### DIFF
--- a/lib/feralchimp.rb
+++ b/lib/feralchimp.rb
@@ -128,9 +128,14 @@ class Feralchimp
           e[:raw_body] = e[:body]
 
           body = e[:body].each_line.to_a
-          keys = ::JSON.parse(body.shift)
-          e[:body] = body.inject([]) do |a, k|
-            a.push(Hash[keys.zip(::JSON.parse(k))])
+
+          e[:body] = if ::JSON.parse(body.first).is_a?(Hash)
+            body.map { |line| ::JSON.parse(line) }
+          else
+            keys = ::JSON.parse(body.shift)
+            body.inject([]) do |a, k|
+              a.push(Hash[keys.zip(::JSON.parse(k))])
+            end
           end
         end
       end

--- a/spec/fixtures/export_json_objects_url.json
+++ b/spec/fixtures/export_json_objects_url.json
@@ -1,0 +1,2 @@
+ {"jack@example.com":[{"action":"open","timestamp":"2016-01-06 21:45:34","url":null,"ip":"10.0.0.1"}]}
+{"jill@example.com":[{"action":"open","timestamp":"2016-01-06 22:08:45","url":null,"ip":"10.0.0.1"}]}

--- a/spec/lib/feralchimp_spec.rb
+++ b/spec/lib/feralchimp_spec.rb
@@ -84,6 +84,35 @@ describe Feralchimp do
     end
   end
 
+  context ".export.campaignSubscriberActivity" do
+    it "parses the output to an array of hashes" do
+      stub_response(:export_json_objects_url)
+      expect(Feralchimp.new(:api_key => "foo-us6").export.campaignSubscriberActivity(id: "abcdefg")).to eq([
+        {
+          "jack@example.com" => [
+            {
+              "action" => "open",
+              "timestamp" => "2016-01-06 21:45:34",
+              "url"=> nil,
+              "ip" => "10.0.0.1"
+            }
+          ]
+        },
+
+        {
+          "jill@example.com" => [
+            {
+              "action" => "open",
+              "timestamp" => "2016-01-06 22:08:45",
+              "url"=> nil,
+              "ip" => "10.0.0.1"
+            }
+          ]
+        }
+      ])
+    end
+  end
+
   it "outputs a hash" do
     stub_response(:mailchimp_url)
     expect(Feralchimp.new(:api_key => "foo-us6").lists).to eq({

--- a/spec/support/feralchimp_helpers.rb
+++ b/spec/support/feralchimp_helpers.rb
@@ -1,4 +1,5 @@
 EXPORT_URL = %r!https://us6.api.mailchimp.com/export/1.0/(?:[a-z0-9]+)!
+EXPORT_JSON_OBJECTS_URL = %r!https://us6.api.mailchimp.com/export/1.0/(?:[a-z0-9]+)!
 MAILCHIMP_URL = %r!https://us6.api.mailchimp.com/\d.\d/(?:[a-z0-9/]+)!
 ERROR_URL = %r!https://us6.api.mailchimp.com/\d.\d/error!
 


### PR DESCRIPTION
Hey @envygeeks 

I took a pass at fixing #14. There are 3 different calls that are part of Mailchimp's v1 export API (https://apidocs.mailchimp.com/export/1.0/). I mentioned in the commit message that export/list is more like a CSV file (it even includes a header row). In your original implementation, you transform it into a nice hash (which is awesome by the way).

Since export/campaignSubscriberActivity is not like a CSV file, the implementation breaks. I tried the simple route of branching if the first row is more like a Hash. If it's a Hash, I just convert each row in the response to a Hash and return it.

Let me know what you think or if you recommend any changes since it's the first time I'm digging into your code.